### PR TITLE
Fixes input pointer was compared to the null

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -674,7 +674,7 @@ CommandMwb::invoke(char* argv[], int argc)
             char* input = readline("? ");
             if (!input)
                 return;
-            if (input == '\0' ||
+            if (*input == '\0' ||
                 !argUint32(input, &value))
             {
                 free(input);
@@ -777,7 +777,7 @@ CommandMww::invoke(char* argv[], int argc)
             char* input = readline("? ");
             if (!input)
                 return;
-            if (input == '\0' ||
+            if (*input == '\0' ||
                 !argUint32(input, &value))
             {
                 free(input);


### PR DESCRIPTION
Fixed the error when you try to compile it in Linux:

```
src/Command.cpp: In member function ‘virtual void CommandMwb::invoke(char**, int)’:
src/Command.cpp:677:26: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
             if (input == '\0' ||
                          ^~~~
src/Command.cpp: In member function ‘virtual void CommandMww::invoke(char**, int)’:
src/Command.cpp:780:26: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
             if (input == '\0' ||

```